### PR TITLE
add response object

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,22 @@ import { RegistryClient } from '@digitalcredentials/issuer-registry-client'
 const registries = new RegistryClient()
 
 // Load the registries from the web (typically done at app startup).
-await registries.load({ config: knownRegistries })
+const result = await registries.load({ config: knownRegistries })
+console.log(result)
+/**
+  [
+  {
+    name: 'DCC Sandbox Registry',
+    url: 'https://digitalcredentials.github.io/sandbox-registry/registry.json',
+    loaded: true
+  },
+  {
+    name: 'DCC Community Registry',
+    url: 'https://digitalcredentials.github.io/community-registry/registry.json',
+    loaded: true
+  }
+]
+ * 
 
 // You can now query to see if a DID is known in any registry
 console.log(registries.didEntry('did:key:z6MkpLDL3RoAoMRTwTgo3rs39ZwssfaPKtGdZw7AGRN7CK4W'))
@@ -133,6 +148,7 @@ DidMapRegistryEntry {
 registries.didEntry('did:example:does-not-exist')
 // undefined
 ```
+
 
 ## Contribute
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,12 +120,12 @@ export class RegistryClient {
             this.didMap.set(did, entry)
           }
         }
-        resultEntry!.loaded = true
+        if (resultEntry != null) resultEntry.loaded = true
       } catch (e) {
         console.log(`Could not load registry from url "${registry.url}":`, e)
         // no DIDs are added from that registry
-        resultEntry!.loaded = false
-        resultEntry!.error = e
+        if (resultEntry != null) resultEntry.loaded = false
+        if (resultEntry != null) resultEntry.error = e
       }
     }))
     return registryLoadResult

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,10 +71,10 @@ export class DidMapRegistryEntry {
   }
 }
 
-export type LoadResult = {
-  name: string,
-  url: string,
-  loaded: boolean,
+export interface LoadResult {
+  name: string
+  url: string
+  loaded: boolean
   error?: any
 }
 
@@ -102,7 +102,7 @@ export class RegistryClient {
     this.registries = config as DidMapRegistry[]
     const registryLoadResult = JSON.parse(JSON.stringify(this.registries)) as LoadResult[]
     await Promise.all(this.registries.map(async (registry) => {
-      const resultEntry = registryLoadResult.find((entry:LoadResult)=>entry.url === registry.url)
+      const resultEntry = registryLoadResult.find((entry: LoadResult) => entry.url === registry.url)
       try {
         // fetch registry contents
         const contents: any = await httpClient.get(registry.url)
@@ -124,7 +124,7 @@ export class RegistryClient {
       } catch (e) {
         console.log(`Could not load registry from url "${registry.url}":`, e)
         // no DIDs are added from that registry
-        resultEntry!.loaded = false;
+        resultEntry!.loaded = false
         resultEntry!.error = e
       }
     }))

--- a/test/registryClient.spec.ts
+++ b/test/registryClient.spec.ts
@@ -42,7 +42,7 @@ describe('registry client', () => {
 
     const result = await client.load({ config: knownIssuers })
     expect(result).to.deep.equal(expectedSuccessfulResult)
-    
+
     const entry = client
       .didEntry('did:key:z6MkpLDL3RoAoMRTwTgo3rs39ZwssfaPKtGdZw7AGRN7CK4W')
     expect(entry?.inRegistries?.size).to.equal(2)
@@ -50,20 +50,19 @@ describe('registry client', () => {
     expect(client.didEntry('did:example:invalid')).to.equal(undefined)
   })
 
-  it.only('returns error response for bad registries', async () => {
+  it('returns error response for bad registries', async () => {
     const client = new RegistryClient()
 
     const result = await client.load({ config: badIssuer })
     console.log(result)
-    expect (result.length).to.equal(2)
-    expect (result.find(entry=>entry.url === 'https://digitalcredentials.github.io/sandbox-registry/registry.json')?.loaded).to.be.true
-    expect (result.find(entry=>entry.url === 'https://digitalcredentials.github.io/community-registry/reggggistry.json')?.loaded).to.be.false
-    
+    expect(result.length).to.equal(2)
+    expect(result.find(entry => entry.url === 'https://digitalcredentials.github.io/sandbox-registry/registry.json')?.loaded).to.be.true
+    expect(result.find(entry => entry.url === 'https://digitalcredentials.github.io/community-registry/reggggistry.json')?.loaded).to.be.false
+
     const entry = client
       .didEntry('did:key:z6MkpLDL3RoAoMRTwTgo3rs39ZwssfaPKtGdZw7AGRN7CK4W')
     expect(entry?.inRegistries?.size).to.equal(1)
 
     expect(client.didEntry('did:example:invalid')).to.equal(undefined)
   })
-
 })

--- a/test/registryClient.spec.ts
+++ b/test/registryClient.spec.ts
@@ -54,10 +54,13 @@ describe('registry client', () => {
     const client = new RegistryClient()
 
     const result = await client.load({ config: badIssuer })
-    console.log(result)
     expect(result.length).to.equal(2)
-    expect(result.find(entry => entry.url === 'https://digitalcredentials.github.io/sandbox-registry/registry.json')?.loaded).to.be.true
-    expect(result.find(entry => entry.url === 'https://digitalcredentials.github.io/community-registry/reggggistry.json')?.loaded).to.be.false
+    
+    const successfulLoad = result.find(entry => entry.url === 'https://digitalcredentials.github.io/sandbox-registry/registry.json')
+    expect(successfulLoad?.loaded).to.equal(true)
+    
+    const failedLoad = result.find(entry => entry.url === 'https://digitalcredentials.github.io/community-registry/reggggistry.json')
+    expect(failedLoad?.loaded).to.equal(false)
 
     const entry = client
       .didEntry('did:key:z6MkpLDL3RoAoMRTwTgo3rs39ZwssfaPKtGdZw7AGRN7CK4W')

--- a/test/registryClient.spec.ts
+++ b/test/registryClient.spec.ts
@@ -1,6 +1,19 @@
 import { expect } from 'chai'
 import { RegistryClient } from '../src'
 
+const expectedSuccessfulResult = [
+  {
+    name: 'DCC Sandbox Registry',
+    url: 'https://digitalcredentials.github.io/sandbox-registry/registry.json',
+    loaded: true
+  },
+  {
+    name: 'DCC Community Registry',
+    url: 'https://digitalcredentials.github.io/community-registry/registry.json',
+    loaded: true
+  }
+]
+
 const knownIssuers = [
   {
     name: 'DCC Sandbox Registry',
@@ -12,16 +25,45 @@ const knownIssuers = [
   }
 ]
 
+const badIssuer = [
+  {
+    name: 'DCC Sandbox Registry',
+    url: 'https://digitalcredentials.github.io/sandbox-registry/registry.json'
+  },
+  {
+    name: 'DCC Community Registry',
+    url: 'https://digitalcredentials.github.io/community-registry/reggggistry.json'
+  }
+]
+
 describe('registry client', () => {
   it('loads registries', async () => {
     const client = new RegistryClient()
 
-    await client.load({ config: knownIssuers })
-
+    const result = await client.load({ config: knownIssuers })
+    expect(result).to.deep.equal(expectedSuccessfulResult)
+    
     const entry = client
       .didEntry('did:key:z6MkpLDL3RoAoMRTwTgo3rs39ZwssfaPKtGdZw7AGRN7CK4W')
     expect(entry?.inRegistries?.size).to.equal(2)
 
     expect(client.didEntry('did:example:invalid')).to.equal(undefined)
   })
+
+  it.only('returns error response for bad registries', async () => {
+    const client = new RegistryClient()
+
+    const result = await client.load({ config: badIssuer })
+    console.log(result)
+    expect (result.length).to.equal(2)
+    expect (result.find(entry=>entry.url === 'https://digitalcredentials.github.io/sandbox-registry/registry.json')?.loaded).to.be.true
+    expect (result.find(entry=>entry.url === 'https://digitalcredentials.github.io/community-registry/reggggistry.json')?.loaded).to.be.false
+    
+    const entry = client
+      .didEntry('did:key:z6MkpLDL3RoAoMRTwTgo3rs39ZwssfaPKtGdZw7AGRN7CK4W')
+    expect(entry?.inRegistries?.size).to.equal(1)
+
+    expect(client.didEntry('did:example:invalid')).to.equal(undefined)
+  })
+
 })


### PR DESCRIPTION
Returns a response object from the load method, like so:

```
[
  {
    name: 'DCC Sandbox Registry',
    url: 'https://digitalcredentials.github.io/sandbox-registry/registry.json',
    loaded: true
  },
  {
    name: 'DCC Community Registry',
    url: 'https://digitalcredentials.github.io/community-registry/registry.json',
    loaded: true
  }
]
```

and when a call fails:

```
[
  {
    name: 'DCC Sandbox Registry',
    url: 'https://digitalcredentials.github.io/sandbox-registry/registry.json',
    loaded: true
  },
  {
    name: 'DCC Community Registry',
    url: 'https://digitalcredentials.github.io/community-registry/reggggistry.json',
    loaded: false,
    error: HTTPError: Request failed with status code 404 Not Found: GET https://digitalcredentials.github.io/community-registry/reggggistry.json
        at function_ (file:///Users/jameschartrand/Documents/github/dcc/issuer-registry-client/node_modules/ky/source/core/Ky.ts:56:17)
        at processTicksAndRejections (node:internal/process/task_queues:95:5)
        at async Ky._retry (file:///Users/jameschartrand/Documents/github/dcc/issuer-registry-client/node_modules/ky/source/core/Ky.ts:258:11)
        at async _handleResponse (/Users/jameschartrand/Documents/github/dcc/issuer-registry-client/node_modules/@digitalcredentials/http-client/dist/httpClient.js:104:16)
        at async /Users/jameschartrand/Documents/github/dcc/issuer-registry-client/src/index.ts:108:31
        at async Promise.all (index 1)
        at async RegistryClient.load (/Users/jameschartrand/Documents/github/dcc/issuer-registry-client/src/index.ts:104:5)
        at async Context.<anonymous> (/Users/jameschartrand/Documents/github/dcc/issuer-registry-client/test/registryClient.spec.ts:56:20) {
      response: [Response],
      request: [Request],
      options: [Object],
      requestUrl: 'https://digitalcredentials.github.io/community-registry/reggggistry.json',
      status: 404
    }
  }
]
```
